### PR TITLE
Add Meetings module with CRUD functionality

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -10,6 +10,7 @@ import { UnitOwnersModule } from './unit-owners/unit-owners.module';
 import { UnitsModule } from './units/units.module';
 import { UsersModule } from './users/users.module';
 import { EmailModule } from './email/email.module';
+import { MeetingsModule } from './meetings/meetings.module';
 
 
 @Module({
@@ -22,7 +23,8 @@ import { EmailModule } from './email/email.module';
     UnitOwnersModule,
     UnitDuesModule,
     ReserveTransactionsModule,
-    EmailModule
+    EmailModule,
+    MeetingsModule
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/server/src/meetings/dto/create-meeting.dto.ts
+++ b/server/src/meetings/dto/create-meeting.dto.ts
@@ -1,0 +1,13 @@
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+
+export class CreateMeetingDto {
+  @IsDateString()
+  meetingDate: string;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/server/src/meetings/dto/update-meeting.dto.ts
+++ b/server/src/meetings/dto/update-meeting.dto.ts
@@ -1,0 +1,15 @@
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+
+export class UpdateMeetingDto {
+  @IsDateString()
+  @IsOptional()
+  meetingDate?: string;
+
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/server/src/meetings/meetings.controller.spec.ts
+++ b/server/src/meetings/meetings.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MeetingsController } from './meetings.controller';
+
+describe('MeetingsController', () => {
+  let controller: MeetingsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MeetingsController],
+    }).compile();
+
+    controller = module.get<MeetingsController>(MeetingsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/meetings/meetings.controller.ts
+++ b/server/src/meetings/meetings.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { MeetingsService } from './meetings.service';
+import { CreateMeetingDto } from './dto/create-meeting.dto';
+import { UpdateMeetingDto } from './dto/update-meeting.dto';
+
+@Controller('meetings')
+export class MeetingsController {
+  constructor(private readonly meetingsService: MeetingsService) {}
+
+  @Get()
+  findAll() {
+    return this.meetingsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.meetingsService.findOne(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateMeetingDto) {
+    return this.meetingsService.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateMeetingDto) {
+    return this.meetingsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.meetingsService.remove(id);
+  }
+}

--- a/server/src/meetings/meetings.module.ts
+++ b/server/src/meetings/meetings.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MeetingsController } from './meetings.controller';
+import { MeetingsService } from './meetings.service';
+
+@Module({
+  controllers: [MeetingsController],
+  providers: [MeetingsService]
+})
+export class MeetingsModule {}

--- a/server/src/meetings/meetings.module.ts
+++ b/server/src/meetings/meetings.module.ts
@@ -4,6 +4,6 @@ import { MeetingsService } from './meetings.service';
 
 @Module({
   controllers: [MeetingsController],
-  providers: [MeetingsService]
+  providers: [MeetingsService],
 })
 export class MeetingsModule {}

--- a/server/src/meetings/meetings.service.spec.ts
+++ b/server/src/meetings/meetings.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MeetingsService } from './meetings.service';
+
+describe('MeetingsService', () => {
+  let service: MeetingsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MeetingsService],
+    }).compile();
+
+    service = module.get<MeetingsService>(MeetingsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/meetings/meetings.service.ts
+++ b/server/src/meetings/meetings.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateMeetingDto } from './dto/create-meeting.dto';
+import { UpdateMeetingDto } from './dto/update-meeting.dto';
+
+@Injectable()
+export class MeetingsService {
+  constructor(private prisma: PrismaService) {}
+
+  async findAll() {
+    return this.prisma.meeting.findMany({
+      orderBy: { meetingDate: 'desc' },
+    });
+  }
+
+  async findOne(meetingId: string) {
+    const meeting = await this.prisma.meeting.findUnique({
+      where: { meetingId },
+    });
+
+    if (!meeting) {
+      throw new NotFoundException('Meeting not found');
+    }
+
+    return meeting;
+  }
+
+  async create(dto: CreateMeetingDto) {
+    return this.prisma.meeting.create({
+      data: {
+        meetingDate: new Date(dto.meetingDate),
+        title: dto.title,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async update(meetingId: string, dto: UpdateMeetingDto) {
+    const existing = await this.prisma.meeting.findUnique({
+      where: { meetingId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Meeting not found');
+    }
+
+    return this.prisma.meeting.update({
+      where: { meetingId },
+      data: {
+        meetingDate: dto.meetingDate ? new Date(dto.meetingDate) : undefined,
+        title: dto.title,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async remove(meetingId: string) {
+    const existing = await this.prisma.meeting.findUnique({
+      where: { meetingId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Meeting not found');
+    }
+
+    await this.prisma.meeting.delete({
+      where: { meetingId },
+    });
+
+    return { deleted: true };
+  }
+}


### PR DESCRIPTION
This PR adds the Meetings backend feature.

What was implemented:
- Created Meetings module (controller, service, DTOs)
- Added full CRUD functionality:
  - Create meeting
  - Get all meetings
  - Get single meeting by ID
  - Update meeting
  - Delete meeting
- Integrated with existing Prisma Meeting model
- Added validation using DTOs (CreateMeetingDto, UpdateMeetingDto)

Notes:
- This builds on the existing database schema (no schema changes required)
- Structure follows NestJS best practices (modular service + controller separation)

Next Steps:
- Connect meetings with documents (Meeting Minutes feature)
- Add file/document linking for meeting records